### PR TITLE
Address bus width changed to 8*beatBytes.

### DIFF
--- a/src/main/scala/freechips/rocketchip/jtag2mm/JtagFuzzer.scala
+++ b/src/main/scala/freechips/rocketchip/jtag2mm/JtagFuzzer.scala
@@ -28,8 +28,8 @@ class JtagFuzzer(irLength: Int, beatBytes: Int, numOfTransfers: Int) extends Mod
     val sIdle, sTCK, sTMS, sTCKandTMS, sNone, sDataTCK, sDataTMS, sDataTCKandTMS, sDataNone  = Value
   }
   
-  val lfsrAddrReg = RegInit(UInt(16.W), 0.U)
-  lfsrAddrReg := LFSR(14) << 2
+  val lfsrAddrReg = RegInit(UInt(32.W), 0.U)
+  lfsrAddrReg := LFSR(30) << 2
   val lfsrDataReg = RegInit(UInt(32.W), 0.U)
   lfsrDataReg := LFSR(32)
   
@@ -310,7 +310,7 @@ class JtagFuzzer(irLength: Int, beatBytes: Int, numOfTransfers: Int) extends Mod
       io.TCK := false.B
       io.TMS := true.B
       when(stateCounter === 68.U) {
-        io.TDI := lfsrAddrReg(15)
+        io.TDI := lfsrAddrReg(31)
       } .elsewhen(stateCounter === 162.U) {
         io.TDI := lfsrDataReg(31)
       } .otherwise {
@@ -341,7 +341,7 @@ class JtagFuzzer(irLength: Int, beatBytes: Int, numOfTransfers: Int) extends Mod
       io.TCK := true.B
       io.TMS := true.B
       when(stateCounter === 69.U) {
-        io.TDI := lfsrAddrReg(15)
+        io.TDI := lfsrAddrReg(31)
       } .elsewhen(stateCounter === 163.U) {
         io.TDI := lfsrDataReg(31)
       } .otherwise {

--- a/src/main/scala/freechips/rocketchip/jtag2mm/JtagToMaster.scala
+++ b/src/main/scala/freechips/rocketchip/jtag2mm/JtagToMaster.scala
@@ -4,10 +4,10 @@ package freechips.rocketchip.jtag2mm
 
 import chisel3._
 import chisel3.util._
-import chipsalliance.rocketchip.config.Parameters
 import chisel3.experimental.{ChiselEnum, IO}
-import freechips.rocketchip.diplomacy._
+import chipsalliance.rocketchip.config.Parameters
 import freechips.rocketchip.amba.axi4._
+import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink.{TLToBundleBridge, _}
 
 
@@ -162,7 +162,7 @@ class JTAGToMasterTL[D, U, E, O, B <: Data](irLength: Int, initialInstruction: B
     currentInstruction := controller.io.output.instruction
 
     val dataValue = RegInit(UInt((beatBytes * 8).W), 0.U)
-    val addressValue = RegInit(UInt((beatBytes * 4).W), 0.U)
+    val addressValue = RegInit(UInt((beatBytes * 8).W), 0.U)
 
     val burstTotalNumber = RegInit(UInt(8.W), 0.U)
     val burstCurrentNumber = RegInit(UInt(8.W), 0.U)
@@ -173,7 +173,7 @@ class JTAGToMasterTL[D, U, E, O, B <: Data](irLength: Int, initialInstruction: B
     }
 
     when(currentInstruction === "b0010".U) {
-      addressValue := controller.io.dataOut >> (beatBytes * 4)
+      addressValue := controller.io.dataOut
     }
 
     when(currentInstruction === "b1000".U) {
@@ -527,7 +527,7 @@ class JTAGToMasterAXI4(irLength: Int, initialInstruction: BigInt, beatBytes: Int
     currentInstruction := controller.io.output.instruction
 
     val dataValue = RegInit(UInt((beatBytes * 8).W), 0.U)
-    val addressValue = RegInit(UInt((beatBytes * 4).W), 0.U)
+    val addressValue = RegInit(UInt((beatBytes * 8).W), 0.U)
 
     val burstTotalNumber = RegInit(UInt(8.W), 0.U)
     val burstCurrentNumber = RegInit(UInt(8.W), 0.U)
@@ -540,7 +540,7 @@ class JTAGToMasterAXI4(irLength: Int, initialInstruction: BigInt, beatBytes: Int
     }
 
     when(currentInstruction === "b0010".U) {
-      addressValue := controller.io.dataOut >> (beatBytes * 4)
+      addressValue := controller.io.dataOut
     }
 
     when(currentInstruction === "b1000".U) {

--- a/src/test/scala/freechips/rocketchip/jtag2mm/Jtag2AXI4MultiplexerTester.scala
+++ b/src/test/scala/freechips/rocketchip/jtag2mm/Jtag2AXI4MultiplexerTester.scala
@@ -108,7 +108,7 @@ class Jtag2AXI4MultiplexerTester(dut: Jtag2AXI4Multiplexer) extends DspTester(du
     
     // write value 0x08 to address 0x00
     jtagSend(BigInt("0010", 2), 4, false, true, stepSize)
-    jtagSend(BigInt("0" * 32, 2), 32, true, false, stepSize)
+    jtagSend(BigInt("0" * 64, 2), 64, true, false, stepSize)
     jtagSend(BigInt("0011", 2), 4, false, false, stepSize)
     jtagSend(BigInt("0" * 56 ++ "00001000", 2), 64, true, false, stepSize)
     jtagSend(BigInt("0001", 2), 4, false, false, stepSize)
@@ -122,7 +122,7 @@ class Jtag2AXI4MultiplexerTester(dut: Jtag2AXI4Multiplexer) extends DspTester(du
 
   /*jtagReset(stepSize)
   jtagSend(BigInt("0010", 2), 4, false, true, stepSize)
-  jtagSend(BigInt("0"*32, 2), 32, true, false, stepSize)
+  jtagSend(BigInt("0"*64, 2), 64, true, false, stepSize)
   jtagSend(BigInt("0011", 2), 4, false, false, stepSize)
   jtagSend(BigInt("0"*56 ++ "00011000", 2), 64, true, false, stepSize)
   jtagSend(BigInt("0001", 2), 4, false, false, stepSize)*/
@@ -131,7 +131,7 @@ class Jtag2AXI4MultiplexerTester(dut: Jtag2AXI4Multiplexer) extends DspTester(du
     
     // set start address for burst write to 0x08 and number of burst transactions to 2
     jtagSend(BigInt("0010", 2), 4, false, false, stepSize)
-    jtagSend(BigInt("0" * 24 ++ "00001000", 2), 32, true, false, stepSize)
+    jtagSend(BigInt("0" * 56 ++ "00001000", 2), 64, true, false, stepSize)
     jtagSend(BigInt("1000", 2), 4, false, false, stepSize)
     jtagSend(BigInt("0" * 6 ++ "10", 2), 8, true, false, stepSize)
     
@@ -195,7 +195,7 @@ class Jtag2AXI4MultiplexerTester(dut: Jtag2AXI4Multiplexer) extends DspTester(du
   
     // set start address for burst read to 0x00 and number of burst transactions to 3
     jtagSend(BigInt("0010", 2), 4, false, false, stepSize)
-    jtagSend(BigInt("0" * 32, 2), 32, true, false, stepSize)
+    jtagSend(BigInt("0" * 64, 2), 64, true, false, stepSize)
     jtagSend(BigInt("1000", 2), 4, false, false, stepSize)
     jtagSend(BigInt("0" * 6 ++ "11", 2), 8, true, false, stepSize)
     

--- a/src/test/scala/freechips/rocketchip/jtag2mm/Jtag2TLMultiplexerTester.scala
+++ b/src/test/scala/freechips/rocketchip/jtag2mm/Jtag2TLMultiplexerTester.scala
@@ -108,7 +108,7 @@ class Jtag2TLMultiplexerTester(dut: Jtag2TLMultiplexer) extends DspTester(dut.mo
     
     // write value 0x08 to address 0x00 
     jtagSend(BigInt("0010", 2), 4, false, true, stepSize)
-    jtagSend(BigInt("0" * 32, 2), 32, true, false, stepSize)
+    jtagSend(BigInt("0" * 64, 2), 64, true, false, stepSize)
     jtagSend(BigInt("0011", 2), 4, false, false, stepSize)
     jtagSend(BigInt("0" * 56 ++ "00001000", 2), 64, true, false, stepSize)
     jtagSend(BigInt("0001", 2), 4, false, false, stepSize)
@@ -122,7 +122,7 @@ class Jtag2TLMultiplexerTester(dut: Jtag2TLMultiplexer) extends DspTester(dut.mo
 
   /*jtagReset(stepSize)
   jtagSend(BigInt("0010", 2), 4, false, true, stepSize)
-  jtagSend(BigInt("0"*32, 2), 32, true, false, stepSize)
+  jtagSend(BigInt("0"*64, 2), 64, true, false, stepSize)
   jtagSend(BigInt("0011", 2), 4, false, false, stepSize)
   jtagSend(BigInt("0"*56 ++ "00011000", 2), 64, true, false, stepSize)
   jtagSend(BigInt("0001", 2), 4, false, false, stepSize)*/
@@ -131,7 +131,7 @@ class Jtag2TLMultiplexerTester(dut: Jtag2TLMultiplexer) extends DspTester(dut.mo
   
     // set start address for burst write to 0x08 and number of burst transactions to 2
     jtagSend(BigInt("0010", 2), 4, false, false, stepSize)
-    jtagSend(BigInt("0" * 24 ++ "00001000", 2), 32, true, false, stepSize)
+    jtagSend(BigInt("0" * 56 ++ "00001000", 2), 64, true, false, stepSize)
     jtagSend(BigInt("1000", 2), 4, false, false, stepSize)
     jtagSend(BigInt("0" * 6 ++ "10", 2), 8, true, false, stepSize)
     
@@ -194,7 +194,7 @@ class Jtag2TLMultiplexerTester(dut: Jtag2TLMultiplexer) extends DspTester(dut.mo
   
     // set start address for burst read to 0x00 and number of burst transactions to 3
     jtagSend(BigInt("0010", 2), 4, false, false, stepSize)
-    jtagSend(BigInt("0" * 32, 2), 32, true, false, stepSize)
+    jtagSend(BigInt("0" * 64, 2), 64, true, false, stepSize)
     jtagSend(BigInt("1000", 2), 4, false, false, stepSize)
     jtagSend(BigInt("0" * 6 ++ "11", 2), 8, true, false, stepSize)
     


### PR DESCRIPTION
This changes the address bus width of the JTAG2MM module to be consistent with and equal to its data bus width.