### PR TITLE
Move MultiIOModule to Module

### DIFF
--- a/src/main/scala/freechips/rocketchip/amba/axi4stream/AXI4StreamModel.scala
+++ b/src/main/scala/freechips/rocketchip/amba/axi4stream/AXI4StreamModel.scala
@@ -242,7 +242,7 @@ class AXI4StreamPeekPokeSlave(port: AXI4StreamBundle, tester: PeekPokeTester[_])
   }
 }
 
-trait AXI4StreamMasterModel extends PeekPokeTester[MultiIOModule] {
+trait AXI4StreamMasterModel extends PeekPokeTester[Module] {
   protected var masters: Seq[AXI4StreamPeekPokeMaster] = Seq()
 
   def resetMaster(port: AXI4StreamBundle): Unit = {
@@ -284,7 +284,7 @@ trait AXI4StreamMasterModel extends PeekPokeTester[MultiIOModule] {
   }
 }
 
-trait AXI4StreamSlaveModel extends PeekPokeTester[MultiIOModule] {
+trait AXI4StreamSlaveModel extends PeekPokeTester[Module] {
   protected var slaves: Seq[AXI4StreamPeekPokeSlave] = Seq()
 
   def resetSlave(port: AXI4StreamBundle): Unit = {

--- a/src/main/scala/freechips/rocketchip/amba/axi4stream/SimpleSplitter.scala
+++ b/src/main/scala/freechips/rocketchip/amba/axi4stream/SimpleSplitter.scala
@@ -1,7 +1,6 @@
 package freechips.rocketchip.amba.axi4stream
 
 import chisel3._
-import freechips.rocketchip.amba.axi4stream.{AXI4StreamMasterPortParameters, AXI4StreamNexusNode, AXI4StreamSlavePortParameters}
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 

--- a/src/main/scala/freechips/rocketchip/jtag2mm/TestMultiplexer.scala
+++ b/src/main/scala/freechips/rocketchip/jtag2mm/TestMultiplexer.scala
@@ -3,7 +3,7 @@
 package freechips.rocketchip.jtag2mm
 
 import chisel3._
-//import chisel3.experimental._
+import chisel3.experimental._
 import chipsalliance.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 import dspblocks._


### PR DESCRIPTION
Since `MultiIOModule` will be deprecated in the future, change it to `Module`.