### PR TITLE
Update deprecated APIs for Chisel 5 update

### DIFF
--- a/doc/Example.md
+++ b/doc/Example.md
@@ -6,7 +6,7 @@ A basic DSP Module + Tester might look like this:
 package SimpleDsp
 
 // Allows you to use Chisel Module, Bundle, etc.
-import chisel3.{fromDoubleToLiteral => _, fromIntToBinaryPoint => _, _}
+import chisel3._
 // Allows you to use FixedPoint
 import fixedpoint._
 // If you want to take advantage of type classes >> Data:RealBits (i.e. pass in FixedPoint or DspReal)

--- a/src/main/scala/dspblocks/TestIP.scala
+++ b/src/main/scala/dspblocks/TestIP.scala
@@ -1,7 +1,7 @@
 package dspblocks
 
 import breeze.math.Complex
-import chisel3.{fromDoubleToLiteral => _, fromIntToBinaryPoint => _, _}
+import chisel3._
 import chiseltest.iotesters.PeekPokeTester
 import fixedpoint._
 import dsptools._


### PR DESCRIPTION
Note that this is not compatible with Chisel 3.6.0.